### PR TITLE
GDB-1846-Added possibility for anonymous user to add GraphDB license file to the configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,18 @@
 
     <build>
         <plugins>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.20</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!--You should add your GraphDB license file in the root directory of the project and name it graphdb.license
+                        or replace ${basedir}/graphdb.license with the full path to your GraphDB license file-->
+                        <graphdb.license.file>${basedir}/graphdb.license</graphdb.license.file>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>


### PR DESCRIPTION
Added surefire plugin in pom.xml to set the graphdb.license.file property which allows users execute Enterprise tests